### PR TITLE
Fix missing acl method _isAllowed in admin controller

### DIFF
--- a/app/code/local/Ffuenf/StockControl/controllers/Adminhtml/StockcontrolController.php
+++ b/app/code/local/Ffuenf/StockControl/controllers/Adminhtml/StockcontrolController.php
@@ -51,4 +51,10 @@ class Ffuenf_StockControl_Adminhtml_StockcontrolController extends Mage_Adminhtm
     {
         return Mage::getModel('stockcontrol/adminhtml_stockcontrol');
     }
+
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('catalog/stockcontrol');
+    }
+
 }


### PR DESCRIPTION
For compatibility with magento 1.9.1+